### PR TITLE
Allow local_mirror to be configurable

### DIFF
--- a/recipes/mirror.rb
+++ b/recipes/mirror.rb
@@ -5,6 +5,13 @@ end
 
 package "nginx"
 
+directory node['pkgsrc']['local_mirror'] do
+  owner "root"
+  group "root"
+  mode 00755
+  action :create
+end
+
 template "/opt/local/etc/nginx/nginx.conf" do
   source "nginx.conf.erb"
   mode 0644

--- a/templates/default/nginx.conf.erb
+++ b/templates/default/nginx.conf.erb
@@ -42,7 +42,7 @@ http {
 
         location / {
             autoindex on;
-            root   share/examples/nginx/html/pkgsrc-joyent;
+            root   <%= node['pkgsrc']['local_mirror'] %>;
             index  index.html index.htm;
         }
 


### PR DESCRIPTION
- Use local_mirror in nginx configuration
- Create local_mirror directory if it is missing
